### PR TITLE
Option to display years in ascending order

### DIFF
--- a/combodate.js
+++ b/combodate.js
@@ -174,10 +174,17 @@
             var items = this.initItems('y'), name, i, 
                 longNames = this.options.template.indexOf('YYYY') !== -1;
 
-            for(i=this.options.maxYear; i>=this.options.minYear; i--) {
-                name = longNames ? i : (i+'').substring(2);
-                items.push([i, name]);
-            }    
+            if (this.options.yearDescending) {
+                for(i=this.options.maxYear; i>=this.options.minYear; i--) {
+                    name = longNames ? i : (i+'').substring(2);
+                    items.push([i, name]);
+                }
+            } else {
+                for(i=this.options.minYear; i<=this.options.maxYear; i++) {
+                    name = longNames ? i : (i+'').substring(2);
+                    items.push([i, name]);
+                }
+            }
             return items;              
         },    
         
@@ -393,6 +400,7 @@
         value: null,                       
         minYear: 1970,
         maxYear: 2015,
+        yearDescending: true,
         minuteStep: 5,
         secondStep: 1,
         firstItem: 'empty', //'name', 'empty', 'none'


### PR DESCRIPTION
The default sort order for all date components is ascending except for year.   However, when selecting dates in the future, it often makes more sense to see the years in ascending order.  This pull request adds a yearDescending option that defaults to true, which reverses year display order when set to false.
