### PR TITLE
Setting date to current year

### DIFF
--- a/src/combodate.js
+++ b/src/combodate.js
@@ -510,7 +510,7 @@
         //initial value, can be `new Date()`
         value: null,
         minYear: 1970,
-        maxYear: 2015,
+        maxYear: new Date().getFullYear(),
         yearDescending: true,
         minuteStep: 5,
         secondStep: 1,


### PR DESCRIPTION
Currently the maxYear is set to 2015 as we in 2016 this will likely break a lot of apps not checking this. I have change this to : new Date().getFullYear() so its always the current year. 
