### PR TITLE
Fixed a bug that populates empty number of day 

### DIFF
--- a/src/combodate.js
+++ b/src/combodate.js
@@ -136,6 +136,11 @@
                 $combo.append('<option value="'+items[i][0]+'">'+items[i][1]+'</option>');
             }
 
+            // BUGFIX: if previous day is 31 Dec, after month selected to Feb, day field becomes empty.
+            if(value > i) {
+                value = i;
+            }
+            
             $combo.val(value);
         },
 


### PR DESCRIPTION
E.g. If previous selected day is 31/Dec, then when month is selected to Feb, the day becomes empty.

The fix in above case changes 31 to biggest day of the month. For, Feb/2017, it becomes 28. 